### PR TITLE
fix: 車作成レッスンでエージェントを前方向に2ブロック先スタートに

### DIFF
--- a/custom.ts
+++ b/custom.ts
@@ -488,6 +488,7 @@ namespace custom {
         else if(orientation < 135) direction = WEST;
 
         agent.teleport(pos(0, 0, 0), direction);
+        agent.move(FORWARD, 2);
     }
 
     function resetArray() {


### PR DESCRIPTION
最終的にtpで最初からこうしておきたい